### PR TITLE
Some simplifications to LV2 wrapper

### DIFF
--- a/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
@@ -14,13 +14,6 @@
 #include "../../juce_core/system/juce_TargetPlatform.h" // for JUCE_LINUX
 
 
-// silence warnings about unused variables (found on
-// https://stackoverflow.com/questions/1486904)
-#ifndef UNUSED
-#define UNUSED(x) (void)(x)
-#endif
-
-
 #if JucePlugin_Build_LV2
 
 /** Plugin requires processing with a fixed/constant block size */
@@ -1690,7 +1683,7 @@ public:
     uint32_t lv2GetOptions (LV2_Options_Option* options)
     {
         // currently unused
-        UNUSED(options);
+        ignoreUnused(options);
 
         return LV2_OPTIONS_SUCCESS;
     }
@@ -1850,7 +1843,7 @@ public:
         info = curPosInfo;
         return true;
 #else
-        UNUSED(info);
+        ignoreUnused(info);
         return false;
 #endif
     }

--- a/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
@@ -251,7 +251,7 @@ const String makeManifestFile (AudioProcessor* const filter, const String& binar
 }
 
 /** Create the -plugin-.ttl file contents */
-const String makePluginFile (AudioProcessor* const filter)
+const String makePluginFile (AudioProcessor* const filter, const int maxNumInputChannels, const int maxNumOutputChannels)
 {
     const String& pluginURI(getPluginURI());
     String text;
@@ -353,7 +353,7 @@ const String makePluginFile (AudioProcessor* const filter)
 #endif
 
     // Audio inputs
-    for (int i=0; i < JucePlugin_MaxNumInputChannels; ++i)
+    for (int i=0; i < maxNumInputChannels; ++i)
     {
         if (i == 0)
             text += "    lv2:port [\n";
@@ -365,14 +365,14 @@ const String makePluginFile (AudioProcessor* const filter)
         text += "        lv2:symbol \"lv2_audio_in_" + String(i+1) + "\" ;\n";
         text += "        lv2:name \"Audio Input " + String(i+1) + "\" ;\n";
 
-        if (i+1 == JucePlugin_MaxNumInputChannels)
+        if (i+1 == maxNumInputChannels)
             text += "    ] ;\n\n";
         else
             text += "    ] ,\n";
     }
 
     // Audio outputs
-    for (int i=0; i < JucePlugin_MaxNumOutputChannels; ++i)
+    for (int i=0; i < maxNumOutputChannels; ++i)
     {
         if (i == 0)
             text += "    lv2:port [\n";
@@ -384,7 +384,7 @@ const String makePluginFile (AudioProcessor* const filter)
         text += "        lv2:symbol \"lv2_audio_out_" + String(i+1) + "\" ;\n";
         text += "        lv2:name \"Audio Output " + String(i+1) + "\" ;\n";
 
-        if (i+1 == JucePlugin_MaxNumOutputChannels)
+        if (i+1 == maxNumOutputChannels)
             text += "    ] ;\n\n";
         else
             text += "    ] ,\n";
@@ -527,7 +527,7 @@ void createLv2Files(const char* basename)
 
     std::cout << "Writing " << binary << ".ttl..."; std::cout.flush();
     std::fstream plugin(binaryTTL.toUTF8(), std::ios::out);
-    plugin << makePluginFile(filter) << std::endl;
+    plugin << makePluginFile(filter, JucePlugin_MaxNumInputChannels, JucePlugin_MaxNumOutputChannels) << std::endl;
     plugin.close();
     std::cout << " done!" << std::endl;
 

--- a/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
@@ -13,6 +13,14 @@
 #include "../utility/juce_CheckSettingMacros.h"
 #include "../../juce_core/system/juce_TargetPlatform.h" // for JUCE_LINUX
 
+
+// silence warnings about unused variables (found on
+// https://stackoverflow.com/questions/1486904)
+#ifndef UNUSED
+#define UNUSED(x) (void)(x)
+#endif
+
+
 #if JucePlugin_Build_LV2
 
 /** Plugin requires processing with a fixed/constant block size */
@@ -1682,6 +1690,8 @@ public:
     uint32_t lv2GetOptions (LV2_Options_Option* options)
     {
         // currently unused
+        UNUSED(options);
+
         return LV2_OPTIONS_SUCCESS;
     }
 
@@ -1840,6 +1850,7 @@ public:
         info = curPosInfo;
         return true;
 #else
+        UNUSED(info);
         return false;
 #endif
     }


### PR DESCRIPTION
Hi falkTX,

in order to make updating the LV2 wrapper to the multichannel API easier, I have simplified the wrapper a little bit.  I didn't get very far, but while I was doing this, I have also suppressed two warnings about unused variables.  Can't hurt... :)

Best,

Martin