### PR TITLE
Fixed crash on second open of OpenGL enalbed plugin.

### DIFF
--- a/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/LV2/juce_LV2_Wrapper.cpp
@@ -915,6 +915,8 @@ public:
         }
         else
         {
+            parentContainer->setVisible (false);
+
             if (parentContainer != nullptr && parentContainer->isOnDesktop())
                 parentContainer->removeFromDesktop();
         }


### PR DESCRIPTION
This fixes a crash on second window open of an LV2 plugin if it's openGL enabled.
There's a separate fix I have on upstream JUCE's side, but they haven't implemented it yet.

I'm not sure *why* it didn't work before, but it wasn't shutting down the openGL context without this new line. Could be another upstream bug.