### PR TITLE
Fix a potential X11 BadWindow error

### DIFF
--- a/modules/juce_gui_basics/native/juce_linux_X11_Windowing.cpp
+++ b/modules/juce_gui_basics/native/juce_linux_X11_Windowing.cpp
@@ -1903,6 +1903,9 @@ public:
         ScopedXLock xlock (display);
         XGetInputFocus (display, &focusedWindow, &revert);
 
+        if (focusedWindow == PointerRoot)
+            return false;
+
         return isParentWindowOf (focusedWindow);
     }
 


### PR DESCRIPTION
When `XGetInputFocus` returns the result `PointerRoot` (1), invoking `XQueryTree` to
check the parent relation will raise the error and crash.


In practice, this occurrence happens in some hosts (in my experience jalv.gtk, but not all of them), when you will launch a dialog and close it extremely shortly afterwards. During a short time frame, you may get `PointerRoot` and crash the plugin + host in the process.