### PR TITLE
VST: fix the plugin build, undefined MidiBuffer

### DIFF
--- a/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp
+++ b/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp
@@ -61,7 +61,6 @@
 
 #include <juce_core/juce_core.h>
 #include "../../juce_audio_processors/format_types/juce_VSTInterface.h"
-#include "../../juce_audio_processors/format_types/juce_VSTMidiEventList.h"
 
 #ifdef _MSC_VER
  #pragma warning (pop)


### PR DESCRIPTION
In "VST wrapper fixing" 65de577a3c82135f4b53ba309c2e014df8b7a810, the inclusion "juce_VSTMidiEventList.h" is added at the top but it breaks the build.

Was there a reason for adding it at this place?
It will be included by "juce_IncludeModuleHeaders.h" some lines down from there.

This is the first error from the build.
```
Compiling include_juce_audio_plugin_client_VST2.cpp
In file included from ../../Thirdparty/JUCE/modules/juce_audio_plugin_client/VST/juce_VST_Wrapper.cpp:64,
                 from ../../Thirdparty/JUCE/modules/juce_audio_plugin_client/juce_audio_plugin_client_VST2.cpp:27,
                 from ../../JuceLibraryCode/include_juce_audio_plugin_client_VST2.cpp:9:
../../Thirdparty/JUCE/modules/juce_audio_plugin_client/VST/../../juce_audio_processors/format_types/juce_VSTMidiEventList.h:108:69: error: 'MidiBuffer' has not been declared
     static void addEventsToMidiBuffer (const VstEventBlock* events, MidiBuffer& dest)
```