### PR TITLE
[Draft] Fix juce_freetype_Fonts.cpp issue, causing to be unable to build JUCE 5 plugins

### DIFF
--- a/modules/juce_graphics/native/juce_freetype_Fonts.cpp
+++ b/modules/juce_graphics/native/juce_freetype_Fonts.cpp
@@ -353,8 +353,8 @@ private:
     bool getGlyphShape (Path& destShape, const FT_Outline& outline, const float scaleX)
     {
         const float scaleY = -scaleX;
-        const short* const contours = outline.contours;
-        const char* const tags = outline.tags;
+        short unsigned int* const contours = outline.contours;
+        unsigned char* const tags = outline.tags;
         const FT_Vector* const points = outline.points;
 
         for (int c = 0; c < outline.n_contours; ++c)


### PR DESCRIPTION
PR for fixing build error described in #24 