### PR TITLE
Fix compilation errors due to upstream change in FreeType

### DIFF
--- a/modules/juce_graphics/native/juce_freetype_Fonts.cpp
+++ b/modules/juce_graphics/native/juce_freetype_Fonts.cpp
@@ -353,8 +353,8 @@ private:
     bool getGlyphShape (Path& destShape, const FT_Outline& outline, const float scaleX)
     {
         const float scaleY = -scaleX;
-        const short* const contours = outline.contours;
-        const char* const tags = outline.tags;
+        auto* const contours = outline.contours;
+        auto* const tags = outline.tags;
         const FT_Vector* const points = outline.points;
 
         for (int c = 0; c < outline.n_contours; ++c)


### PR DESCRIPTION
Fix #24.

FreeType [changed the type](https://github.com/freetype/freetype/commit/2a7bb4596f566a34fd53932af0ef53b956459d25) of some variables upstream, causing compilation errors due to JUCE 5 hardcoding those types. This PR is similar to #23, but just [backports the change](https://github.com/juce-framework/JUCE/commit/dee78f29f60dbe46e436872971b18e260522e8a4) from upstream JUCE: change the variables to `auto`.